### PR TITLE
New tooltip

### DIFF
--- a/folium/__init__.py
+++ b/folium/__init__.py
@@ -18,7 +18,7 @@ from folium.raster_layers import TileLayer, WmsTileLayer
 from folium.folium import Map
 
 from folium.map import (
-    FeatureGroup, FitBounds, Icon, LayerControl, Marker, Popup
+    FeatureGroup, FitBounds, Icon, LayerControl, Marker, Popup, Tooltip
 )
 
 from folium.vector_layers import Circle, CircleMarker, PolyLine, Polygon, Rectangle  # noqa

--- a/folium/features.py
+++ b/folium/features.py
@@ -414,7 +414,7 @@ class GeoJson(Layer):
 
         self.highlight_function = highlight_function or (lambda x: {})
 
-        self.add_child(tooltip)
+        self.add_child(tooltip, name=tooltip._name)
 
         if isinstance(tooltip, Tooltip):
             if tooltip.fields:

--- a/folium/features.py
+++ b/folium/features.py
@@ -377,33 +377,6 @@ class GeoJson(Layer):
                         }
                     {% endif %}
                     )
-                    {% if this.tooltip %}
-                    .bindTooltip(function(layer){
-                    {% if this.tooltip.fields %}
-                    let fields = {{ this.tooltip.fields }};
-                        {% if this.tooltip.aliases %}
-                    let aliases = {{ this.tooltip.aliases }};
-                        {% endif %}
-                    return String(
-                        fields.map(
-                        columnname=>
-                            `{% if this.tooltip.labels %}
-                            <strong>{% if this.tooltip.aliases %}${aliases[fields.indexOf(columnname)]
-                                {% if this.tooltip.toLocaleString %}.toLocaleString(){% endif %}}
-                            {% else %}
-                            ${ columnname{% if this.tooltip.toLocaleString %}.toLocaleString(){% endif %}}
-                            {% endif %}</strong>:
-                            {% endif %}
-                            ${ layer.feature.properties[columnname]
-                            {% if this.tooltip.toLocaleString %}.toLocaleString(){% endif %} }`
-                        ).join('<br>'))
-                    {% elif this.tooltip.text %}
-                        return String(`{{ this.tooltip.text.__str__() }}`)
-                    {% else %}
-                        return String(`{{ this.tooltip.__str__() }}`)
-                    {% endif %}
-                    },{sticky: {% if this.tooltip.result %}{{ this.tooltip.sticky.__str__().lower() }}{%else %}true{%endif%}})
-                    {% endif %}
                     .addTo({{this._parent.get_name()}});
                 {{this.get_name()}}.setStyle(function(feature) {return feature.properties.style;});
 
@@ -443,10 +416,10 @@ class GeoJson(Layer):
 
         self.add_child(tooltip)
 
-        if isinstance(self.tooltip, Tooltip):
-            if self.tooltip.fields:
+        if isinstance(tooltip, Tooltip):
+            if tooltip.fields:
                 keys = self.data['features'][0]['properties'].keys()
-                for value in list(self.tooltip.fields):
+                for value in list(tooltip.fields):
                     assert value in keys, "The value " + value.__str__() + \
                                           " is not available in the values " + \
                                           keys.__str__()

--- a/folium/features.py
+++ b/folium/features.py
@@ -13,7 +13,7 @@ from branca.colormap import LinearColormap
 from branca.element import (CssLink, Element, Figure, JavascriptLink, MacroElement)  # noqa
 from branca.utilities import (_locations_tolist, _parse_size, image_to_url, iter_points, none_max, none_min)  # noqa
 
-from folium.map import FeatureGroup, Icon, Layer, Marker
+from folium.map import FeatureGroup, Icon, Layer, Marker, Tooltip
 from folium.utilities import get_bounds
 from folium.vector_layers import PolyLine
 
@@ -435,14 +435,13 @@ class GeoJson(Layer):
             self.data = json.loads(json.dumps(data.__geo_interface__))  # noqa
         else:
             raise ValueError('Unhandled object {!r}.'.format(data))
-
         self.style_function = style_function or (lambda x: {})
 
         self.highlight = highlight_function is not None
 
         self.highlight_function = highlight_function or (lambda x: {})
 
-        self.tooltip = tooltip
+        self.add_child(tooltip)
 
         if isinstance(self.tooltip, Tooltip):
             if self.tooltip.fields:
@@ -685,80 +684,6 @@ class DivIcon(MacroElement):
         self.popup_anchor = popup_anchor
         self.html = html
         self.className = class_name
-
-
-class Tooltip(object):
-    """
-    Creates a Tooltip object for adding to features to display text as a
-    property by executing a javascript function when hovering the cursor over
-    each feature.
-
-    Parameters
-    ----------
-    fields: list or tuple.
-        Labels of the GeoJson 'properties' or GeoPandas GeodataFrame columns
-         you'd like to display.
-    aliases: list or tuple of strings, the same legnth as fields.
-        Optional 'aliases' you'd like to display the each field name as, to
-        describe the data in the tooltip.
-    text: str, may not be passed if fields is not None.
-        Pass the same string as a tooltip for every value in the GeoJson
-        object, I.e. "Click for more info."
-    labels: boolean, defaults True.
-        Boolean value indicating if you'd like the the field names or
-        aliases to display to the left of the value in bold.
-    sticky: boolean, defaults True.
-        Boolean value indicating if you'd like the tooltip to 'sticky' with
-        the mouse cursor as it moves.
-        *If False, the tooltip will place statically at the centroid of the
-        feature.
-    toLocaleString: boolean, defaults False.
-        This will use JavaScript's .toLocaleString() to format 'clean' values
-        as strings for the user's location; i.e. 1,000,000.00 comma separators,
-        float truncation for the US, etc.
-        *Available for most of JavaScript's primitive types (any data you'll
-        serve into the template).
-
-    Examples
-    --------
-    # Provide fields and aliases
-    >>> Tooltip(fields=['CNTY_NM','census-pop-2015','census-md-income-2015'],
-                aliases=['County','2015 Census Population',
-                        '2015 Median Income'],
-                labels=True,
-                sticky=False,
-                toLocaleString=True)
-    # Provide fields, with labels off, and sticky True.
-    >>> Tooltip(fields=('CNTY_NM',), labels=False, sticky=True)
-    # Provide only text.
-    >>> Tooltip(text="Click for more info.", sticky=True)
-    """
-
-    def __init__(self, text=None, fields=None, aliases=None, labels=True,
-                 sticky=True, toLocaleString=False):
-        if fields:
-            assert isinstance(fields, (list, tuple)), "Please pass a list or " \
-                                                      "tuple to Fields."
-        if bool(fields) & bool(aliases):
-            assert isinstance(aliases, (list, tuple))
-            assert len(fields) == len(aliases), "Fields and Aliases must have" \
-                                                " the same length."
-        assert isinstance(labels, bool), "This field requires a boolean value."
-        assert isinstance(sticky, bool), "This field requires a boolean value."
-        assert not all((fields, text)), "Please choose either fields or text."
-        assert any((fields, text)), "Please choose either fields or text."
-        assert isinstance(toLocaleString, bool), "toLocaleString must be " \
-                                                 "boolean."
-        self.fields = fields
-        self.aliases = aliases
-        self.text = text
-        self.labels = labels
-        self.sticky = sticky
-        self.toLocaleString = toLocaleString
-        if self.fields:
-            self.result = self.fields
-        else:
-            self.result = self.text
 
 
 class LatLngPopup(MacroElement):

--- a/folium/features.py
+++ b/folium/features.py
@@ -413,17 +413,16 @@ class GeoJson(Layer):
         self.highlight = highlight_function is not None
 
         self.highlight_function = highlight_function or (lambda x: {})
-        
-        if tooltip:
-            self.add_child(tooltip, name=tooltip._name)
 
-        if isinstance(tooltip, Tooltip):
-            if tooltip.fields:
-                keys = self.data['features'][0]['properties'].keys()
-                for value in list(tooltip.fields):
-                    assert value in keys, "The value " + value.__str__() + \
-                                          " is not available in the values " + \
-                                          keys.__str__()
+        if tooltip:
+            if isinstance(tooltip, Tooltip):
+                if tooltip.fields:
+                    keys = self.data['features'][0]['properties'].keys()
+                    for value in list(tooltip.fields):
+                        assert value in keys, "The value " + value.__str__() + \
+                                              " is not available in the values " + \
+                                              keys.__str__()
+            self.add_child(tooltip, name=tooltip._name)
 
         self.smooth_factor = smooth_factor
 

--- a/folium/features.py
+++ b/folium/features.py
@@ -413,8 +413,9 @@ class GeoJson(Layer):
         self.highlight = highlight_function is not None
 
         self.highlight_function = highlight_function or (lambda x: {})
-
-        self.add_child(tooltip, name=tooltip._name)
+        
+        if tooltip:
+            self.add_child(tooltip, name=tooltip._name)
 
         if isinstance(tooltip, Tooltip):
             if tooltip.fields:

--- a/folium/folium.py
+++ b/folium/folium.py
@@ -15,7 +15,7 @@ from branca.colormap import StepColormap
 from branca.element import CssLink, Element, Figure, JavascriptLink, MacroElement
 from branca.utilities import _parse_size, color_brewer
 
-from folium.features import GeoJson, TopoJson, Tooltip
+from folium.features import GeoJson, TopoJson
 from folium.map import FitBounds
 from folium.raster_layers import TileLayer
 from folium.utilities import _validate_location

--- a/folium/map.py
+++ b/folium/map.py
@@ -228,7 +228,7 @@ class Marker(MacroElement):
     >>> Marker(location=[45.5, -122.3], popup=folium.Popup('Portland, OR'))
     # If the popup label has characters that need to be escaped in HTML
     >>> Marker(location=[45.5, -122.3],
-               popoup=folium.Popup('Mom & Pop Arrow Shop >>', parse_html=True))
+               popup=folium.Popup('Mom & Pop Arrow Shop >>', parse_html=True))
     """
     _template = Template(u"""
             {% macro script(this, kwargs) %}
@@ -255,7 +255,6 @@ class Marker(MacroElement):
             self.add_child(Popup(popup))
         elif popup is not None:
             self.add_child(popup)
-
     def _get_self_bounds(self):
         """
         Computes the bounds of the object itself (not including it's children)
@@ -333,6 +332,118 @@ class Popup(Element):
         figure.script.add_child(Element(
             self._template.render(this=self, kwargs=kwargs)),
             name=self.get_name())
+
+
+class Tooltip(object):
+    """
+    Creates a Tooltip object for adding to features to display text as a
+    property by executing a JavaScript function when hovering the cursor over
+    each feature.
+
+    Parameters
+    ----------
+    fields: list or tuple.
+        Labels of the GeoJson 'properties' or GeoPandas GeodataFrame columns
+         you'd like to display.
+    aliases: list or tuple of strings, the same length as fields.
+        Optional 'aliases' you'd like to display the each field name as, to
+        describe the data in the tooltip.
+    text: str, may not be passed if fields is not None.
+        Pass the same string as a tooltip for every value in the GeoJson
+        object, I.e. "Click for more info."
+    labels: boolean, defaults True.
+        Boolean value indicating if you'd like the the field names or
+        aliases to display to the left of the value in bold.
+    sticky: boolean, defaults True.
+        Boolean value indicating if you'd like the tooltip to 'sticky' with
+        the mouse cursor as it moves.
+        *If False, the tooltip will place statically at the centroid of the
+        feature.
+    toLocaleString: boolean, defaults False.
+        This will use JavaScript's .toLocaleString() to format 'clean' values
+        as strings for the user's location; i.e. 1,000,000.00 comma separators,
+        float truncation, etc.
+        *Available for most of JavaScript's primitive types (any data you'll
+        serve into the template).
+
+    Examples
+    --------
+    # Provide fields and aliases
+    >>> Tooltip(fields=['CNTY_NM','census-pop-2015','census-md-income-2015'],
+                aliases=['County','2015 Census Population',
+                        '2015 Median Income'],
+                labels=True,
+                sticky=False,
+                toLocaleString=True)
+    # Provide fields, with labels off, and sticky True.
+    >>> Tooltip(fields=('CNTY_NM',), labels=False, sticky=True)
+    # Provide only text.
+    >>> Tooltip(text="Click for more info.", sticky=True)
+    """
+    _template = Template(u"""
+            var {{this.get_name()}} = new L.tooltip({{ this.kwargs }})
+                .setContent(
+                    function(layer){
+                    {% if this.fields %}
+                    let fields = {{ this.fields }};
+                    {% if this.aliases %}
+                    let aliases = {{ this.aliases }};
+                    {% endif %}
+                    return String(
+                        fields.map(
+                        columnname=>
+                            `{% if this.labels %}
+                            <strong>{% if this.aliases %}${aliases[fields.indexOf(columnname)]
+                                {% if this.toLocaleString %}.toLocaleString(){% endif %}}
+                            {% else %}
+                            ${ columnname{% if this.toLocaleString %}.toLocaleString(){% endif %}}
+                            {% endif %}</strong>:
+                            {% endif %}
+                            ${ layer.feature.properties[columnname]
+                            {% if this.toLocaleString %}.toLocaleString(){% endif %} }`
+                        ).join('<br>'))
+                    {% elif this.text %}
+                        return String(`{{ this.text.__str__() }}`)
+                    {% else %}
+                        return String(`{{ this.__str__() }}`)
+                    {% endif %}
+                    }
+                )
+            {{ this._parent.get_name() }}.bindTooltip({{ this.get_name() }})
+        """)
+
+    def __init__(self, text=None, fields=None, aliases=None, labels=True,
+                 toLocaleString=False, **kwargs):
+        super(Tooltip, self).__init__()
+        if fields:
+            assert isinstance(fields, (list, tuple)), "Please pass a list or " \
+                                                      "tuple to Fields."
+        if bool(fields) & bool(aliases):
+            assert isinstance(aliases, (list, tuple))
+            assert len(fields) == len(aliases), "Fields and Aliases must have" \
+                                                " the same length."
+        assert isinstance(labels, bool), "This field requires a boolean value."
+        assert isinstance(sticky, bool), "This field requires a boolean value."
+        assert not all((fields, text)), "Please choose either fields or text."
+        assert any((fields, text)), "Please choose either fields or text."
+        assert isinstance(toLocaleString, bool), "toLocaleString must be " \
+                                                 "boolean."
+        allowed_keys = ("pane", "offset", "direction", "permanent", "sticky",
+                             "interactive", "opacity")
+        for key in kwargs.keys():
+            assert key in self.allowed_keys, "The key " + key + 'was not in ' \
+                                    'the allowed keys'+ allowed_keys.__str__()
+        # Handle boolean conversion in Jinja template
+        self.kwargs = {key:str(kwargs[key]).lower() for key in kwargs}
+        self.fields = fields
+        self.aliases = aliases
+        self.text = text
+        self.labels = labels
+        self.toLocaleString = toLocaleString
+        if self.fields:
+            self.result = self.fields
+        else:
+            self.result = self.text
 
 
 class FitBounds(MacroElement):

--- a/folium/map.py
+++ b/folium/map.py
@@ -362,7 +362,7 @@ class Tooltip(MacroElement):
         serve into the template).
     **kwargs: Assorted.
         These values will map directly to the Leaflet Options. More info
-        available here: https://leafletjs.com/reference-1.0.0.html#tooltip
+        available here: https://leafletjs.com/reference-1.3.0.html#tooltip
 
     Examples
     --------

--- a/folium/map.py
+++ b/folium/map.py
@@ -381,39 +381,44 @@ class Tooltip(Element):
     >>> Tooltip(text="Click for more info.", sticky=True)
     """
     _template = Template(u"""
-            var {{this.get_name()}} = new L.tooltip({{ this.kwargs }})
-                .setContent(
-                    function(layer){
-                    {% if this.fields %}
-                    let fields = {{ this.fields }};
-                    {% if this.aliases %}
-                    let aliases = {{ this.aliases }};
-                    {% endif %}
-                    return String(
-                        fields.map(
-                        columnname=>
-                            `{% if this.labels %}
-                            <strong>{% if this.aliases %}${aliases[fields.indexOf(columnname)]
-                                {% if this.toLocaleString %}.toLocaleString(){% endif %}}
-                            {% else %}
-                            ${ columnname{% if this.toLocaleString %}.toLocaleString(){% endif %}}
-                            {% endif %}</strong>:
-                            {% endif %}
-                            ${ layer.feature.properties[columnname]
-                            {% if this.toLocaleString %}.toLocaleString(){% endif %} }`
-                        ).join('<br>'))
-                    {% elif this.text %}
-                        return String(`{{ this.text.__str__() }}`)
-                    {% else %}
-                        return String(`{{ this.__str__() }}`)
-                    {% endif %}
-                    });
+            var {{this.get_name()}} = L.tooltip({{ this.kwargs }})
+            .setContent(
+                function(layer){
+                {% if this.fields %}
+                let fields = {{ this.fields }};
+                {% if this.aliases %}
+                let aliases = {{ this.aliases }};
+                {% endif %}
+                return String(
+                    fields.map(
+                    columnname=>
+                        `{% if this.labels %}
+                        <strong>{% if this.aliases %}${aliases[fields.indexOf(columnname)]
+                            {% if this.toLocaleString %}.toLocaleString(){% endif %}}
+                        {% else %}
+                        ${ columnname{% if this.toLocaleString %}.toLocaleString(){% endif %}}
+                        {% endif %}</strong>:
+                        {% endif %}
+                        ${ layer.feature.properties[columnname]
+                        {% if this.toLocaleString %}.toLocaleString(){% endif %} }`
+                    ).join('<br>'))
+                {% elif this.text %}
+                    return String(`{{ this.text.__str__() }}`)
+                {% else %}
+                    return String(`{{ this.__str__() }}`)
+                {% endif %}
+                });
             {{ this._parent.get_name() }}.bindTooltip({{ this.get_name() }});
         """)
 
     def __init__(self, text=None, fields=None, aliases=None, labels=True,
                  toLocaleString=False, **kwargs):
         super(Tooltip, self).__init__()
+        self._name = "Tooltip"
+        self.header = Element()
+        self.html = Element()
+        self.script = Element()
+
         if fields:
             assert isinstance(fields, (list, tuple)), "Please pass a list or " \
                                                       "tuple to Fields."
@@ -431,9 +436,8 @@ class Tooltip(Element):
                              "sticky", "interactive", "opacity")
         for key in kwargs.keys():
             assert key in self.allowed_keys, "The key " + key + 'was not in ' \
-                                'the allowed keys'+ self.allowed_keys.__str__()
-        # Handle boolean conversion in Jinja template
-        self.kwargs = {key:str(kwargs[key]).lower() for key in kwargs}
+                                'the allowed keys: '+ self.allowed_keys.__str__()
+        self.kwargs = json.dumps(kwargs)
         self.fields = fields
         self.aliases = aliases
         self.text = text

--- a/folium/map.py
+++ b/folium/map.py
@@ -401,7 +401,7 @@ class Tooltip(MacroElement):
                         {% if this.toLocaleString %}.toLocaleString(){% endif %} }`
                     ).join('<br>'))
                 {% elif this.text %}
-                    return String(`{{ this.text.__str__() }}`)
+                    return String(`{{ this.text }}`)
                 {% else %}
                     return String(`{{ this.__str__() }}`)
                 {% endif %}
@@ -416,25 +416,34 @@ class Tooltip(MacroElement):
 
         if fields:
             assert isinstance(fields, (list, tuple)), "Please pass a list or " \
-                                                      "tuple to Fields."
-        if bool(fields) & bool(aliases):
+                                                      "tuple to fields."
+        if all((fields, aliases)):
             assert isinstance(aliases, (list, tuple))
-            assert len(fields) == len(aliases), "Fields and Aliases must have" \
+            assert len(fields) == len(aliases), "fields and aliases must have" \
                                                 " the same length."
-        assert isinstance(labels, bool), "This field requires a boolean value."
+        assert isinstance(labels, bool), "labels requires a boolean value."
         assert not all((fields, text)), "Please choose either fields or text."
         assert any((fields, text)), "Please choose either fields or text."
         assert isinstance(toLocaleString, bool), "toLocaleString must be " \
                                                  "boolean."
-        self.allowed_keys = ("pane", "offset", "direction", "permanent",
-                             "sticky", "interactive", "opacity")
-        for key in kwargs.keys():
-            assert key in self.allowed_keys, "The key " + key + 'was not in ' \
-                                'the allowed keys: '+ self.allowed_keys.__str__()
-        self.kwargs = json.dumps(kwargs)
+        self.valid_kwargs = {"pane": (str,),
+                             "offset": (tuple,),
+                             "direction": (str,),
+                             "permanent": (bool,),
+                             "sticky": (bool,),
+                             "interactive": (bool,),
+                             "opacity": (float, int)}
+        if kwargs:
+            for key in kwargs.keys():
+                assert key in self.valid_kwargs.keys(), "The key {0} was not" \
+                  + " in the allowed keys: {1}".format(key, self.valid_kwargs)
+                assert isinstance(kwargs[key], self.valid_kwargs[key]), \
+                    "{0} must be of the following types: {1}".format(key,
+                                                         self.valid_kwargs[key])
+            self.kwargs = json.dumps(kwargs)
         self.fields = fields
         self.aliases = aliases
-        self.text = text
+        self.text = text.__str__()
         self.labels = labels
         self.toLocaleString = toLocaleString
         if self.fields:

--- a/folium/map.py
+++ b/folium/map.py
@@ -334,7 +334,7 @@ class Popup(Element):
             name=self.get_name())
 
 
-class Tooltip(object):
+class Tooltip(Element):
     """
     Creates a Tooltip object for adding to features to display text as a
     property by executing a JavaScript function when hovering the cursor over
@@ -407,9 +407,8 @@ class Tooltip(object):
                     {% else %}
                         return String(`{{ this.__str__() }}`)
                     {% endif %}
-                    }
-                )
-            {{ this._parent.get_name() }}.bindTooltip({{ this.get_name() }})
+                    });
+            {{ this._parent.get_name() }}.bindTooltip({{ this.get_name() }});
         """)
 
     def __init__(self, text=None, fields=None, aliases=None, labels=True,
@@ -423,16 +422,16 @@ class Tooltip(object):
             assert len(fields) == len(aliases), "Fields and Aliases must have" \
                                                 " the same length."
         assert isinstance(labels, bool), "This field requires a boolean value."
-        assert isinstance(sticky, bool), "This field requires a boolean value."
+        # assert isinstance(sticky, bool), "This field requires a boolean value."
         assert not all((fields, text)), "Please choose either fields or text."
         assert any((fields, text)), "Please choose either fields or text."
         assert isinstance(toLocaleString, bool), "toLocaleString must be " \
                                                  "boolean."
-        allowed_keys = ("pane", "offset", "direction", "permanent", "sticky",
-                             "interactive", "opacity")
+        self.allowed_keys = ("pane", "offset", "direction", "permanent",
+                             "sticky", "interactive", "opacity")
         for key in kwargs.keys():
             assert key in self.allowed_keys, "The key " + key + 'was not in ' \
-                                    'the allowed keys'+ allowed_keys.__str__()
+                                'the allowed keys'+ self.allowed_keys.__str__()
         # Handle boolean conversion in Jinja template
         self.kwargs = {key:str(kwargs[key]).lower() for key in kwargs}
         self.fields = fields

--- a/folium/map.py
+++ b/folium/map.py
@@ -405,7 +405,7 @@ class Tooltip(MacroElement):
                 {% else %}
                     return String(`{{ this.__str__() }}`)
                 {% endif %}
-                }{{ this.kwargs }});
+                }{% if this.kwargs %}, {{ this.kwargs }}{% endif %});
             {% endmacro %}
         """)
 


### PR DESCRIPTION
Most of the issues have been addressed and `folium.map.Tooltip` now runs as expected on a GeoJSON object.

Before adding `self.add_child(tootlip)` to other folium map objects,  I think it would be good to incorporate some tests on the args, i.e. make sure that only the `text` arg is passed and not both fields. This would be possible prior to `self.add_child(tooltip)`, no problem. However, something I've realized with moving the `tooltip` template to `Tooltip` class, is that we no longer have the option of passing a raw string to the `GeoJson(tooltip)` arg. I think that it should be robust enough to handle normal string input (as it did previously) in addition to `Tooltip` objects.