### PR TITLE
Tooltip Styles, Topojson and Marker/Vector Functionality

### DIFF
--- a/folium/features.py
+++ b/folium/features.py
@@ -73,7 +73,7 @@ class RegularPolygonMarker(Marker):
                     radius: {{this.radius}}
                     }
                 ){% if this.tooltip %}
-                .bindTooltip('{{ this.tooltip }})
+                .bindTooltip('{{ this.tooltip }}')
                 {% endif %}
                 .addTo({{this._parent.get_name()}});
             {% endmacro %}

--- a/folium/features.py
+++ b/folium/features.py
@@ -438,9 +438,8 @@ class GeoJson(Layer):
                 if tooltip.fields:
                     keys = self.data['features'][0]['properties'].keys()
                     for value in list(tooltip.fields):
-                        assert value in keys, "The value " + value.__str__() + \
-                                              " is not available in the values " + \
-                                              keys.__str__()
+                        assert value in keys, "The value {0} is not available" \
+                                              " in {1}".format(value, keys)
                 self.add_child(tooltip, name=tooltip._name)
             elif isinstance(tooltip, str):
                 self.tooltip = tooltip.__str__()
@@ -535,7 +534,7 @@ class TopoJson(Layer):
                             , {smoothFactor: {{this.smooth_factor}}}
                         {% endif %}
                         )
-                        {% if this.tooltip %}.bindTooltip("{{this.tooltip.__str__()}}"){% endif %}
+                        {% if this.tooltip %}.bindTooltip("{{this.tooltip}}"){% endif %}
                         .addTo({{this._parent.get_name()}});
                 {{this.get_name()}}.setStyle(function(feature) {return feature.properties.style;});
 
@@ -548,7 +547,19 @@ class TopoJson(Layer):
         super(TopoJson, self).__init__(name=name, overlay=overlay,
                                        control=control, show=show)
         self._name = 'TopoJson'
-        self.tooltip = tooltip
+        if tooltip:
+            if isinstance(tooltip, Tooltip):
+                if tooltip.fields:
+                    keys = self.data['objects'][object_path]['geometries'][0].keys()
+                    for value in list(tooltip.fields):
+                        assert value in keys, "The value {0} is not available" \
+                                              " in {1}".format(value, keys)
+                self.add_child(tooltip, name=tooltip._name)
+            elif isinstance(tooltip, str):
+                self.tooltip = tooltip.__str__()
+            else:
+                raise ValueError('Please pass a folium Tooltip object or'
+                                 ' a string to the tooltip argument')
         if 'read' in dir(data):
             self.embed = True
             self.data = json.load(data)

--- a/folium/features.py
+++ b/folium/features.py
@@ -547,19 +547,7 @@ class TopoJson(Layer):
         super(TopoJson, self).__init__(name=name, overlay=overlay,
                                        control=control, show=show)
         self._name = 'TopoJson'
-        if tooltip:
-            if isinstance(tooltip, Tooltip):
-                if tooltip.fields:
-                    keys = self.data['objects'][object_path]['geometries'][0].keys()
-                    for value in list(tooltip.fields):
-                        assert value in keys, "The value {0} is not available" \
-                                              " in {1}".format(value, keys)
-                self.add_child(tooltip, name=tooltip._name)
-            elif isinstance(tooltip, str):
-                self.tooltip = tooltip.__str__()
-            else:
-                raise ValueError('Please pass a folium Tooltip object or'
-                                 ' a string to the tooltip argument')
+
         if 'read' in dir(data):
             self.embed = True
             self.data = json.load(data)
@@ -578,6 +566,21 @@ class TopoJson(Layer):
         self.style_function = style_function
 
         self.smooth_factor = smooth_factor
+
+        if tooltip:
+            if isinstance(tooltip, Tooltip):
+                if tooltip.fields:
+                    keys = self.data['objects'][object_path.split('.')[-1]][
+                        'geometries'][0]['properties'].keys()
+                    for value in list(tooltip.fields):
+                        assert value in keys, "The value {0} is not ".format(
+                            value) + "available in {0}".format(keys)
+                self.add_child(tooltip, name=tooltip._name)
+            elif isinstance(tooltip, str):
+                self.tooltip = tooltip.__str__()
+            else:
+                raise ValueError('Please pass a folium Tooltip object or'
+                                 ' a string to the tooltip argument')
 
     def style_data(self):
         """

--- a/folium/map.py
+++ b/folium/map.py
@@ -449,11 +449,13 @@ class Tooltip(MacroElement):
                              "opacity": (float, int)}
         if kwargs:
             for key in kwargs.keys():
-                assert key in self.valid_kwargs.keys(), "The key {0} was not" \
-                  + " in the allowed keys: {1}".format(key, self.valid_kwargs)
+                assert key in self.valid_kwargs.keys(), "The key {0} was not " \
+                                                        "available in the " \
+                                                        "keys: {1}".format(
+                    key, ', '.join(self.valid_kwargs.keys()))
                 assert isinstance(kwargs[key], self.valid_kwargs[key]), \
-                    "{0} must be of the following types: {1}".format(key,
-                                                         self.valid_kwargs[key])
+                    "{0} must be of the following " \
+                    "types: {1}".format(key, self.valid_kwargs[key])
             self.kwargs = json.dumps(kwargs)
         self.fields = fields
         self.aliases = aliases

--- a/folium/map.py
+++ b/folium/map.py
@@ -374,19 +374,25 @@ class Tooltip(MacroElement):
         float truncation, etc.
         *Available for most of JavaScript's primitive types (any data you'll
         serve into the template).
+    style: str. Default None.
+        A string with HTML inline style properties that will be used to style
+        properties like font and colors in a div element in the tooltip.
+        https://www.w3schools.com/html/html_css.asp
     **kwargs: Assorted.
         These values will map directly to the Leaflet Options. More info
         available here: https://leafletjs.com/reference-1.3.0.html#tooltip
 
     Examples
     --------
-    # Provide fields and aliases
+    # Provide fields and aliases, with Style.
     >>> Tooltip(fields=['CNTY_NM','census-pop-2015','census-md-income-2015'],
                 aliases=['County','2015 Census Population',
                         '2015 Median Income'],
                 labels=True,
-                sticky=False,
-                toLocaleString=True)
+                sticky=True,
+                toLocaleString=True,
+                style='background-color: grey; color: white; font-family:
+                courier new; font-size: 24px; padding: 10px;')
     # Provide fields, with labels off, and sticky True.
     >>> Tooltip(fields=('CNTY_NM',), labels=False, sticky=True)
     # Provide only text.
@@ -401,7 +407,8 @@ class Tooltip(MacroElement):
                 {% if this.aliases %}
                 let aliases = {{ this.aliases }};
                 {% endif %}
-                return String(
+                return '<div{% if this.style %} style="{{this.style}}"{% endif%}>' +
+                String(
                     fields.map(
                     columnname=>
                         `{% if this.labels %}
@@ -409,22 +416,23 @@ class Tooltip(MacroElement):
                             {% if this.toLocaleString %}.toLocaleString(){% endif %}}
                         {% else %}
                         ${ columnname{% if this.toLocaleString %}.toLocaleString(){% endif %}}
-                        {% endif %}</strong>:
+                        {% endif %}:</strong>
                         {% endif %}
                         ${ layer.feature.properties[columnname]
                         {% if this.toLocaleString %}.toLocaleString(){% endif %} }`
-                    ).join('<br>'))
+                    ).join('<br>'))+'</div>'
                 {% elif this.text %}
-                    return String(`{{ this.text }}`)
+                    return '<div{% if this.style %} style="{{this.style}}"{% endif%}>' 
+                    + '{{ this.text }}'+'</div>'
                 {% else %}
-                    return String(`{{ this.__str__() }}`)
+                    return '<div{%if this.style%} style="{{this.style}}"{%endif%}>'+'{{ this.__str__() }}'+'</div>'
                 {% endif %}
                 }{% if this.kwargs %}, {{ this.kwargs }}{% endif %});
             {% endmacro %}
         """)
 
     def __init__(self, text=None, fields=None, aliases=None, labels=True,
-                 toLocaleString=False, **kwargs):
+                 toLocaleString=False, style=None, **kwargs):
         super(Tooltip, self).__init__()
         self._name = "Tooltip"
 
@@ -462,6 +470,11 @@ class Tooltip(MacroElement):
         self.text = text.__str__()
         self.labels = labels
         self.toLocaleString = toLocaleString
+        if style:
+            assert isinstance(style, str), \
+                "Pass a valid inline HTML style property string to style." #noqa
+            #  outside of type checking.
+            self.style = style
         if self.fields:
             self.result = self.fields
         else:


### PR DESCRIPTION
Added style parameter to Tooltip, which now wraps a div HTML element containing its contents, allowing users to pass in custom CSS styles.

Toolitp is now functional for the tooltip arguments on GeoJSON, TopoJSON, and every Marker and Vector class. Super excited about this!